### PR TITLE
Fix: Prioritize selection over state when selecting an activity

### DIFF
--- a/src/ui/components/ActivitySelecter/activityUtils.ts
+++ b/src/ui/components/ActivitySelecter/activityUtils.ts
@@ -315,8 +315,8 @@ export const selectFinalCategory = (
     },
     handleChange: (response: responseType, value: string | boolean | undefined) => void,
 ) => {
-    const id = states.selectedId ? states.selectedId : inputs.selection.id;
-    const label = states.labelOfSelectedId ? states.labelOfSelectedId : inputs.selection.label;
+    const id = inputs.selection.id ? inputs.selection.id : states.selectedId;
+    const label = inputs.selection.label ?  inputs.selection.label : states.labelOfSelectedId;
 
     saveNewOrCurrentActivity(
         id,

--- a/src/ui/components/ActivitySelecter/activityUtils.ts
+++ b/src/ui/components/ActivitySelecter/activityUtils.ts
@@ -316,7 +316,7 @@ export const selectFinalCategory = (
     handleChange: (response: responseType, value: string | boolean | undefined) => void,
 ) => {
     const id = inputs.selection.id ? inputs.selection.id : states.selectedId;
-    const label = inputs.selection.label ?  inputs.selection.label : states.labelOfSelectedId;
+    const label = inputs.selection.label ? inputs.selection.label : states.labelOfSelectedId;
 
     saveNewOrCurrentActivity(
         id,


### PR DESCRIPTION
When selecting a final activity the saved activity was used (and broadcast to handleChange) instead of the selecting value 